### PR TITLE
use HTTPS to download all source tarballs

### DIFF
--- a/Makefile
+++ b/Makefile
@@ -308,7 +308,7 @@ download-sources:
 	git clone https://github.com/creytiv/rem.git
 	git clone https://github.com/creytiv/re.git
 	git clone https://github.com/openssl/openssl.git -b OpenSSL_1_1_1-stable openssl
-	wget http://downloads.xiph.org/releases/opus/opus-1.3.1.tar.gz
+	wget https://downloads.xiph.org/releases/opus/opus-1.3.1.tar.gz
 	tar zxf opus-1.3.1.tar.gz
 	rm opus-1.3.1.tar.gz
 	mv opus-1.3.1 opus


### PR DESCRIPTION
It is the least level of security that software should use for dependencies.  The downloads.xiph.org URL does the same redirect whether HTTP or HTTPS:

```console
 ~ $ curl --head http://downloads.xiph.org/releases/opus/opus-1.3.1.tar.gz
HTTP/1.1 302 Moved Temporarily
Server: nginx/1.14.2
Date: Wed, 27 May 2020 13:29:54 GMT
Content-Type: text/html
Content-Length: 161
Connection: keep-alive
Location: https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.3.1.tar.gz
Strict-Transport-Security: max-age=63072000
Proxy-Connection: keep-alive

 ~ $ curl --head https://downloads.xiph.org/releases/opus/opus-1.3.1.tar.gz
HTTP/1.1 200 Connection established

HTTP/2 302 
server: nginx/1.14.2
date: Wed, 27 May 2020 13:30:00 GMT
content-type: text/html
content-length: 161
location: https://ftp.osuosl.org/pub/xiph/releases/opus/opus-1.3.1.tar.gz
strict-transport-security: max-age=63072000
```